### PR TITLE
Fix .projections.json and add `tests` directory

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -3,12 +3,15 @@
         "type": "readme"
     },
     "src/*.rs": {
-        "alternate": "src/{}:test.rs",
-        "type": "source"
+        "type": "src",
+        "alternate": "tests/{}.rs"
     },
-    "src/*:test.rs": {
-        "alternate": "src/{}.rs",
+    "tests/*.rs": {
         "type": "test",
-        "dispatch": "cargo test {file}"
+        "alternate": "src/{}.rs",
+        "dispatch": "cargo test {}"
+    },
+    "Cargo.toml": {
+        "type": "config"
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn main() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
Previously, the Projection's "dispatch" command wasn't working
correctly.